### PR TITLE
Add narrative case and expand case pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ new patterns, start from the template below:
 
 The patterns collected here group into five overarching modes of instructional organization:
 
-1. **Case Patterns** – Narrative scenarios that develop decision-making and critical thinking. Variants include Decision, Evaluation, Problem-Diagnosis and Outlier cases and are well suited to ethics, law, leadership, healthcare and business courses.
+1. **Case Patterns** – Narrative scenarios that develop decision-making and critical thinking. [See case-based subpatterns](case_patterns/README.md) such as Decision, Evaluation, Problem-Diagnosis, Narrative, Outlier, Role-Play and Longitudinal cases. These are well suited to ethics, law, leadership, healthcare and business courses.
 2. **Problem Patterns** – Problem‑based learning challenges where students investigate ill‑structured problems, test hypotheses and iterate on solutions. These fit STEM fields, analytics, diagnostics and engineering.
 3. **Practice Patterns** – Structured repetition to build fluency, from guided to independent work, drawing on techniques like distributed or deliberate practice. Common in quantitative disciplines.
 4. **Design Patterns** – Project‑based approaches that have learners prototype and iterate on artifacts through milestone‑driven cycles such as design thinking. Useful for instructional design, IT, education and business innovation.

--- a/case_patterns/README.md
+++ b/case_patterns/README.md
@@ -1,0 +1,35 @@
+# Case-Based Patterns
+
+Case-based patterns immerse learners in realistic scenarios where they practice professional judgement. They draw on experiential and situated learning theories, using stories that mirror how experts tackle ambiguous problems.
+
+## Classification
+
+- **Pattern Type:** Experience Pattern
+- **Category:** Case-Based Learning
+- **Use Level:** Course, Module, Activity
+- **Applicable Contexts:** Online, hybrid and competency-based education
+
+## Pattern Types
+
+- [Decision Case](decision_case.md)
+- [Evaluation Case](evaluation_case.md)
+- [Problem-Diagnosis Case](problem_diagnosis_case.md)
+- [Narrative Case](narrative_case.md)
+- [Outlier Case](outlier_case.md)
+- [Role-Play Case](role_play_case.md)
+- [Longitudinal Case](longitudinal_case.md)
+
+These patterns can be sequenced from guided to open-ended and return to earlier scenarios with new lenses over time.
+
+## Design Principles
+- Use authentic details with some ambiguity so learners sift the important facts from "noise."
+- Provide scaffolds such as analysis frameworks and reflection prompts.
+- Offer multiple ways to engage and respond to support UDL.
+
+## Sequencing and Integration
+- Start with directed cases, then progress toward open-ended or longitudinal formats.
+- Revisit earlier cases through different perspectives (e.g., ethics or policy) to deepen understanding.
+
+## Online and Hybrid Tips
+- Share prompting questions beforehand to ensure preparation.
+- During synchronous sessions, combine polls, breakout rooms and shared documents to keep discussion lively.

--- a/case_patterns/decision_case.md
+++ b/case_patterns/decision_case.md
@@ -1,0 +1,16 @@
+# Decision Case
+
+Sometimes called a dilemma case, this format presents a stakeholder facing a problem that must be solved. Learners analyze alternatives, weigh trade-offs and justify a final course of action. Example: a CEO choosing a strategy under uncertainty.
+
+## Structure
+1. Welcome
+2. Read the Case
+3. Identify Key Decision Point
+4. Explore Options
+5. Make a Decision
+6. Explain or Defend the Decision
+7. Receive Feedback
+8. Celebrate and Reflect
+
+## Use Cases
+Business, ethics, leadership, management and education policy

--- a/case_patterns/evaluation_case.md
+++ b/case_patterns/evaluation_case.md
@@ -1,0 +1,16 @@
+# Evaluation Case
+
+Learners critique past decisions or actions against objectives or standards. They judge what was done well and what could have been improved. Example: analyzing whether a merger delivered the promised results.
+
+## Structure
+1. Welcome
+2. Read the Case
+3. Identify Key Decision Point
+4. Explore Options
+5. Make a Decision
+6. Explain or Defend the Decision
+7. Receive Feedback
+8. Celebrate and Reflect
+
+## Use Cases
+Quality assurance, program reviews, healthcare diagnostics and engineering

--- a/case_patterns/longitudinal_case.md
+++ b/case_patterns/longitudinal_case.md
@@ -1,0 +1,6 @@
+# Longitudinal Case
+
+Learners follow a single case over time, often receiving new information in stages. This approach highlights the consequences of earlier decisions and develops process thinking.
+
+## Use Cases
+Medical education, project management and business strategy

--- a/case_patterns/narrative_case.md
+++ b/case_patterns/narrative_case.md
@@ -1,0 +1,13 @@
+# Narrative / Exploratory Case
+
+Also called an exploratory case, this format provides a rich story without a single correct answer. Students trace events, consider multiple perspectives and draw insights from complexity.
+
+## Structure
+1. Present the Story
+2. Explore Perspectives
+3. Identify Key Factors
+4. Discuss Insights
+5. Summarize Takeaways
+
+## Use Cases
+History, social issues, and science courses where context and nuance matter.

--- a/case_patterns/outlier_case.md
+++ b/case_patterns/outlier_case.md
@@ -1,0 +1,6 @@
+# Outlier Case
+
+These cases intentionally feature atypical or extreme situations that violate usual patterns. They push learners to question assumptions and refine broader generalizations.
+
+## Use Cases
+Complex systems, ethics, social justice and emerging technologies

--- a/case_patterns/problem_diagnosis_case.md
+++ b/case_patterns/problem_diagnosis_case.md
@@ -1,0 +1,13 @@
+# Problem-Diagnosis Case
+
+Also called an analysis or issue case, learners sift through symptoms to diagnose the underlying cause of a complex problem and then propose solutions. Example: an engineering failure analysis or epidemiological investigation.
+
+## Structure
+1. Read the Situation
+2. Identify Symptoms
+3. Diagnose the Root Cause
+4. Propose Solutions
+5. Justify Recommendations
+
+## Use Cases
+Engineering, medical diagnostics, IT troubleshooting and business analytics

--- a/case_patterns/role_play_case.md
+++ b/case_patterns/role_play_case.md
@@ -1,0 +1,6 @@
+# Role-Play Case
+
+Students assume stakeholder roles to debate or negotiate from different perspectives. This interactive format builds empathy and communication skills and often simulates meetings or negotiations.
+
+## Use Cases
+Policy, law, negotiation and human resources


### PR DESCRIPTION
## Summary
- mention narrative cases in the main README
- add new narrative case page and link from case pattern overview
- enrich the overview with design, sequencing and online tips
- expand text on decision, evaluation, problem-diagnosis, outlier, role-play and longitudinal case pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b32cc2a1c8323b4931426d73b9594